### PR TITLE
changed order of where app css is loaded

### DIFF
--- a/src/index.dev.ts
+++ b/src/index.dev.ts
@@ -5,15 +5,15 @@ import 'angular-material'
 import 'LogUnobtrusiveExtension/dist/log-ex-unobtrusive'
 import 'ng-stats'
 
+// app css
+import './app.scss'
+
 // app imports
 import Common from './common/common.ts'
 import Components from './components/components.ts'
 
 import {App} from './app.ts'
 import AppConfig from './app.config.ts'
-
-// app css
-import './app.scss'
 
 // top level angular module for app
 angular.module('app', [

--- a/src/index.release.ts
+++ b/src/index.release.ts
@@ -5,15 +5,15 @@ import '@angular/router/angular1/angular_1_router'
 import 'LogUnobtrusiveExtension/dist/log-ex-unobtrusive'
 // import 'ng-stats'
 
+// app css
+import './app.scss'
+
 // app imports
 import Common from './common/common.ts'
 import Components from './components/components.ts'
 
 import {App} from './app.ts'
 import AppConfig from './app.config.ts'
-
-// app css
-import './app.scss'
 
 // top level angular module for app
 angular.module('app', [


### PR DESCRIPTION
Noticed that when I was including normalize in my code it wasn't at the top of the css file. If we change the order in which these files were being added to webpack then it was fixed. This seems to make sense to me.